### PR TITLE
Fix calendar date selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,15 @@ function endOfMonth(d){ return new Date(d.getFullYear(), d.getMonth()+1, 0); }
 function addDays(d,n){ const x=new Date(d); x.setDate(x.getDate()+n); return x; }
 function sameDay(a,b){ return a.getFullYear()===b.getFullYear() && a.getMonth()===b.getMonth() && a.getDate()===b.getDate(); }
 
+function fmtDate(d){
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+function parseDateString(str){
+  const [y,m,day] = str.split('-').map(Number);
+  return new Date(y, m-1, day);
+}
+let selectedDate = fmtDate(new Date());
+
 function renderCalendar(){
   $('#calTitle').textContent = currentMonth.toLocaleString(undefined,{month:'long',year:'numeric'});
   const w = $('#weekdays'); w.innerHTML=''; WEEK.forEach(d=>{const el=document.createElement('div'); el.textContent=d; w.appendChild(el)});
@@ -236,7 +245,7 @@ function renderCalendar(){
   const today = new Date();
   for(let i=0;i<rows;i++){
     const date = addDays(first, i-offset);
-    const ds = date.toISOString().slice(0,10);
+    const ds = fmtDate(date);
     const cell = document.createElement('div');
     cell.className='day'+(date.getMonth()!==currentMonth.getMonth()?' other':'')+(sameDay(date,today)?' today':'');
     const num = document.createElement('div'); num.className='num'; num.textContent=date.getDate(); cell.appendChild(num);
@@ -248,13 +257,14 @@ function renderCalendar(){
     cell.addEventListener('click',()=>showAgenda(ds));
     grid.appendChild(cell);
   }
-  showAgenda(new Date().toISOString().slice(0,10));
+  showAgenda(selectedDate);
 }
 
 function showAgenda(ds){
+  selectedDate = ds;
   const wrap = $('#agenda');
   const items = store.events.filter(e=>e.date===ds).sort((a,b)=>(a.start||'').localeCompare(b.start||''));
-  if(items.length===0){ wrap.innerHTML = `<div class="small">No events on ${new Date(ds).toDateString()}</div>`; return; }
+  if(items.length===0){ wrap.innerHTML = `<div class="small">No events on ${parseDateString(ds).toDateString()}</div>`; return; }
   wrap.innerHTML = items.map(e=>`
     <div class="item card">
       <div>
@@ -271,7 +281,7 @@ function showAgenda(ds){
 $('#quickAddEvent').onclick=()=>openEventForm();
 
 function openEventForm(existing){
-  let data = existing || {id:uid(), title:'', type:'Shoot', date:new Date().toISOString().slice(0,10), start:'', end:'', location:'', projectId:''};
+  let data = existing || {id:uid(), title:'', type:'Shoot', date:selectedDate, start:'', end:'', location:'', projectId:''};
   openModal(existing?'Edit Event':'New Event', (body)=>{
     body.append(formRow(`<div><div class="small">Title</div><input id="evTitle" value="${data.title}"></div>`));
     body.append(formRow(`<div><div class="small">Type</div><select id="evType">


### PR DESCRIPTION
## Summary
- handle calendar dates in local time to prevent incorrect day selection
- ensure agenda and new event forms use selected day consistently

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce7842b648320afce6bfdb657bda1