### PR TITLE
Fix calendar date selection and add storyboard and notes features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Cinematix Planner (PWA)
-A clean, modern, offline‑first planner tailored for filmmakers: **calendar**, **shooting days**, **VFX shots**, **tasks**, and **project tracking**.
+A clean, modern, offline‑first planner tailored for filmmakers: **calendar**, **shooting days**, **shots**, **storyboards**, **tasks**, **notes**, and **project tracking**.
 
 ## Highlights
 - Gorgeous dark UI with gradient cards & high‑contrast chips
-- **Calendar month view** with per‑day event chips (Shoot, Deadline, Review, Delivery, VFX) + daily **Agenda**
+- **Calendar month view** with per‑day event chips (Shoot, Deadline, Review, Delivery, Shot) + daily **Agenda**
 - **Projects** (client, color, due date, notes) with quick add **events/tasks**
-- **VFX Shots** tracker (Sequence/Scene/Shot, Vendor, Status: Bid/WIP/Review/Final, Due, Notes)
+- **Shots** tracker (Sequence/Scene/Shot, Vendor, Status: Bid/WIP/Review/Final, Due, Notes) and **Storyboards** with images and reordering
 - **Tasks** with status pipeline (Open → In Progress → Blocked → Done)
+- **Notes** with taggable links to projects, shots, tasks, events, or dates
 - **Modal forms** (no ugly prompts) for fast mobile entry
-- **Floating Action Button** adds the right thing depending on the tab
 - **Import/Export** all data as JSON (local only) for backup/migration
 - **PWA**: Works offline, Add to Home Screen on iPhone
 - **Portrait** design, fits iPhone 16 Pro (max‑width 480px)

--- a/index.html
+++ b/index.html
@@ -16,11 +16,12 @@
   --ok:#22c55e; --warn:#f59e0b; --danger:#ef4444;
 }
 *{box-sizing:border-box} html,body{height:100%}
-body{margin:0;background:radial-gradient(1200px 600px at 50% -200px, #0f1724 0%, #0b0f15 55%), linear-gradient(180deg,#0b0f15 0,#0b0f15 100%);
+html{background:#0b0f15}
+body{margin:0;padding:env(safe-area-inset-top) 0 env(safe-area-inset-bottom);background:radial-gradient(1200px 600px at 50% -200px, #0f1724 0%, #0b0f15 55%), linear-gradient(180deg,#0b0f15 0,#0b0f15 100%);
   color:var(--text); font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,Helvetica,Arial,sans-serif; -webkit-font-smoothing:antialiased}
-.container{max-width:480px;margin:0 auto;padding:14px 14px calc(env(safe-area-inset-bottom) + 18px)}
+.container{max-width:480px;margin:0 auto;padding:14px 14px 18px}
 /* Top bar */
-header.top{position:sticky;top:0;z-index:20;background:rgba(11,15,21,.72);backdrop-filter:blur(10px);
+header.top{position:sticky;top:env(safe-area-inset-top);z-index:20;background:rgba(11,15,21,.72);backdrop-filter:blur(10px);
   border-bottom:1px solid rgba(255,255,255,.06); padding:10px 12px; display:flex; align-items:center; gap:10px}
 .logo{display:flex;align-items:center;gap:10px;font-weight:900;letter-spacing:.3px}
 .logo .glyph{width:24px;height:24px;border-radius:8px;background:conic-gradient(from 0deg, var(--accent), var(--accent2), var(--accent3), var(--accent));
@@ -29,7 +30,7 @@ header.top{position:sticky;top:0;z-index:20;background:rgba(11,15,21,.72);backdr
 .btn.primary{background:linear-gradient(180deg, var(--accent), #2dad9e); color:#042e2a; border:none}
 .btn.ghost{background:transparent}
 /* Tabs */
-.tabs{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin:10px 0}
+  .tabs{display:grid;grid-template-columns:repeat(5,1fr);gap:8px;margin:10px 0}
 .tab{padding:10px;text-align:center;border:1px solid var(--line);border-radius:12px;background:linear-gradient(180deg,#131b25,#0f141c);color:var(--muted);font-weight:800}
 .tab.active{background:linear-gradient(180deg,var(--accent),#2dad9e);color:#042e2a;border-color:transparent}
 /* Cards & layout */
@@ -45,21 +46,18 @@ textarea{min-height:90px;resize:vertical}
 .calendar .head{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px}
 .weekdays,.cal{display:grid;grid-template-columns:repeat(7,1fr);gap:6px}
 .weekdays div{font-size:12px;color:var(--muted);text-align:center}
-.day{border:1px solid var(--line);border-radius:12px;min-height:78px;background:linear-gradient(180deg,#131b22,#0f141c);padding:8px;display:flex;flex-direction:column}
+.day{border:1px solid var(--line);border-radius:12px;min-height:70px;background:linear-gradient(180deg,#131b22,#0f141c);padding:8px;display:flex;flex-direction:column}
 .day .num{font-weight:900;opacity:.95;margin-bottom:8px}
 .day.other{opacity:.45}
 .day.today{outline:2px solid var(--accent2)}
 .chips{display:flex;gap:4px;flex-wrap:wrap}
 .chip{font-size:10px;font-weight:900;padding:2px 7px;border-radius:999px;color:#041e1b}
-.chip.shoot{background:var(--accent3)} .chip.deadline{background:var(--warn)} .chip.review{background:var(--accent2)} .chip.delivery{background:var(--danger)} .chip.vfx{background:var(--accent)}
+.chip.shoot{background:var(--accent3)} .chip.deadline{background:var(--warn)} .chip.review{background:var(--accent2)} .chip.delivery{background:var(--danger)} .chip.shot{background:var(--accent)}
 /* Lists */
 .item{display:grid;grid-template-columns:1fr auto;gap:10px;align-items:start}
 .item+.item{margin-top:10px}
 .item h3{margin:0}
 .kicker{font-size:12px;color:var(--muted)}
-/* Fab */
-.fab{position:fixed;right:18px;bottom:calc(env(safe-area-inset-bottom) + 22px);z-index:40}
-.fab .btn{border-radius:999px;padding:14px 18px;box-shadow:0 10px 30px rgba(0,0,0,.3)}
 /* Modal */
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:none;align-items:flex-end;z-index:50}
 .sheet{width:100%;max-width:520px;margin:0 auto;background:linear-gradient(180deg,#151e29,#111822);border-top-left-radius:16px;border-top-right-radius:16px;border:1px solid var(--line);padding:14px;box-shadow:0 -10px 30px rgba(0,0,0,.35)}
@@ -82,8 +80,9 @@ textarea{min-height:90px;resize:vertical}
   <div class="tabs">
     <div class="tab active" data-tab="calendar">Calendar</div>
     <div class="tab" data-tab="projects">Projects</div>
-    <div class="tab" data-tab="shots">VFX Shots</div>
+    <div class="tab" data-tab="shots">Shots</div>
     <div class="tab" data-tab="tasks">Tasks</div>
+    <div class="tab" data-tab="notes">Notes</div>
   </div>
 
   <!-- CALENDAR -->
@@ -119,7 +118,7 @@ textarea{min-height:90px;resize:vertical}
     <div id="projectsList" style="margin-top:10px"></div>
   </section>
 
-  <!-- SHOTS (VFX) -->
+  <!-- SHOTS -->
   <section id="tab-shots" style="display:none">
     <div class="card">
       <div class="row">
@@ -131,9 +130,11 @@ textarea{min-height:90px;resize:vertical}
           <option value="Final">Final</option>
         </select>
         <div class="space"></div>
+        <button class="btn" id="btnNewStoryboard">+ Storyboard</button>
         <button class="btn primary" id="btnNewShot">+ Shot</button>
       </div>
     </div>
+    <div id="storyboardsList" style="margin-top:10px"></div>
     <div id="shotsList" style="margin-top:10px"></div>
   </section>
 
@@ -155,11 +156,20 @@ textarea{min-height:90px;resize:vertical}
     <div id="tasksList" style="margin-top:10px"></div>
   </section>
 
+  <!-- NOTES -->
+  <section id="tab-notes" style="display:none">
+    <div class="card">
+      <div class="row">
+        <select id="noteFilter"><option value="all">All</option></select>
+        <div class="space"></div>
+        <button class="btn primary" id="btnNewNote">+ Note</button>
+      </div>
+    </div>
+    <div id="notesList" style="margin-top:10px"></div>
+  </section>
+
   <div class="footer">Offline‑ready • Add to Home Screen from Safari</div>
 </div>
-
-<!-- Floating add (contextual) -->
-<div class="fab"><button class="btn primary" id="fabAdd">+ Add</button></div>
 
 <!-- Modal sheet -->
 <div class="modal" id="modal">
@@ -184,20 +194,42 @@ function load(){ try{return JSON.parse(localStorage.getItem(KEY)||'{}')}catch{re
 function save(s){ localStorage.setItem(KEY, JSON.stringify(s)); }
 function init(){
   const s = load();
-  s.projects = s.projects||[];
-  s.events = s.events||[];
-  s.tasks = s.tasks||[];
-  s.shots = s.shots||[]; // VFX shots
+  s.projects = s.projects || [];
+  s.events = s.events || [];
+  s.tasks = s.tasks || [];
+  s.shots = s.shots || []; // Shots
+  s.storyboards = s.storyboards || [];
+  s.notes = s.notes || [];
   return s;
 }
 let store = init();
 
 // ---------- Helpers ----------
-const $ = sel=>document.querySelector(sel);
-const $$ = sel=>Array.from(document.querySelectorAll(sel));
-function uid(){ return (crypto.randomUUID?crypto.randomUUID():Math.random().toString(36).slice(2)); }
-function fmt(d){ return d?new Date(d).toLocaleDateString():''; }
+const $ = sel => document.querySelector(sel);
+const $$ = sel => Array.from(document.querySelectorAll(sel));
+function uid(){ return (crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)); }
+function fmt(d){ return d ? new Date(d).toLocaleDateString() : ''; }
 function formRow(html){ const d=document.createElement('div'); d.innerHTML=html; return d.firstElementChild; }
+function getLabel(type,id){
+  if(type==='project') return store.projects.find(p=>p.id===id)?.title||'Project';
+  if(type==='shot'){ const s=store.shots.find(x=>x.id===id); return s?`${s.sequence||'SEQ'} / ${s.scene||'SC'} / ${s.shot||'SHOT'}`:'Shot'; }
+  if(type==='task') return store.tasks.find(t=>t.id===id)?.title||'Task';
+  if(type==='event') return store.events.find(e=>e.id===id)?.title||'Event';
+  if(type==='date') return id;
+  return type;
+}
+function renderNoteText(txt){
+  return txt
+    .replace(/\[\[(\w+):([^\]]+)\]\]/g,(m,type,id)=>`<span class="badge" onclick="openLinked('${type}','${id}')">${getLabel(type,id)}</span>`)
+    .replace(/\n/g,'<br>');
+}
+function openLinked(type,id){
+  if(type==='project'){ $('.tab[data-tab="projects"]').click(); openProjectForm(store.projects.find(x=>x.id===id)); }
+  else if(type==='shot'){ $('.tab[data-tab="shots"]').click(); openShotForm(store.shots.find(x=>x.id===id)); }
+  else if(type==='task'){ $('.tab[data-tab="tasks"]').click(); editTask(id); }
+  else if(type==='event'){ $('.tab[data-tab="calendar"]').click(); editEvent(id); }
+  else if(type==='date'){ $('.tab[data-tab="calendar"]').click(); showAgenda(id); }
+}
 function openModal(title, bodyBuilder, onSave, onDelete){
   $('#modalTitle').textContent=title;
   const body = $('#modalBody'); body.innerHTML=''; bodyBuilder(body);
@@ -227,6 +259,15 @@ function endOfMonth(d){ return new Date(d.getFullYear(), d.getMonth()+1, 0); }
 function addDays(d,n){ const x=new Date(d); x.setDate(x.getDate()+n); return x; }
 function sameDay(a,b){ return a.getFullYear()===b.getFullYear() && a.getMonth()===b.getMonth() && a.getDate()===b.getDate(); }
 
+function fmtDate(d){
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+function parseDateString(str){
+  const [y,m,day] = str.split('-').map(Number);
+  return new Date(y, m-1, day);
+}
+let selectedDate = fmtDate(new Date());
+
 function renderCalendar(){
   $('#calTitle').textContent = currentMonth.toLocaleString(undefined,{month:'long',year:'numeric'});
   const w = $('#weekdays'); w.innerHTML=''; WEEK.forEach(d=>{const el=document.createElement('div'); el.textContent=d; w.appendChild(el)});
@@ -236,7 +277,7 @@ function renderCalendar(){
   const today = new Date();
   for(let i=0;i<rows;i++){
     const date = addDays(first, i-offset);
-    const ds = date.toISOString().slice(0,10);
+    const ds = fmtDate(date);
     const cell = document.createElement('div');
     cell.className='day'+(date.getMonth()!==currentMonth.getMonth()?' other':'')+(sameDay(date,today)?' today':'');
     const num = document.createElement('div'); num.className='num'; num.textContent=date.getDate(); cell.appendChild(num);
@@ -248,13 +289,14 @@ function renderCalendar(){
     cell.addEventListener('click',()=>showAgenda(ds));
     grid.appendChild(cell);
   }
-  showAgenda(new Date().toISOString().slice(0,10));
+  showAgenda(selectedDate);
 }
 
 function showAgenda(ds){
+  selectedDate = ds;
   const wrap = $('#agenda');
   const items = store.events.filter(e=>e.date===ds).sort((a,b)=>(a.start||'').localeCompare(b.start||''));
-  if(items.length===0){ wrap.innerHTML = `<div class="small">No events on ${new Date(ds).toDateString()}</div>`; return; }
+  if(items.length===0){ wrap.innerHTML = `<div class="small">No events on ${parseDateString(ds).toDateString()}</div>`; return; }
   wrap.innerHTML = items.map(e=>`
     <div class="item card">
       <div>
@@ -271,11 +313,11 @@ function showAgenda(ds){
 $('#quickAddEvent').onclick=()=>openEventForm();
 
 function openEventForm(existing){
-  let data = existing || {id:uid(), title:'', type:'Shoot', date:new Date().toISOString().slice(0,10), start:'', end:'', location:'', projectId:''};
+  let data = existing || {id:uid(), title:'', type:'Shoot', date:selectedDate, start:'', end:'', location:'', projectId:''};
   openModal(existing?'Edit Event':'New Event', (body)=>{
     body.append(formRow(`<div><div class="small">Title</div><input id="evTitle" value="${data.title}"></div>`));
     body.append(formRow(`<div><div class="small">Type</div><select id="evType">
-      ${['Shoot','Deadline','Review','Delivery','VFX'].map(t=>`<option ${data.type===t?'selected':''}>${t}</option>`).join('')}
+      ${['Shoot','Deadline','Review','Delivery','Shot'].map(t=>`<option ${data.type===t?'selected':''}>${t}</option>`).join('')}
     </select></div>`));
     body.append(formRow(`<div class="row"><div class="space"><div class="small">Date</div><input id="evDate" type="date" value="${data.date}"></div>
       <div class="space"><div class="small">Start</div><input id="evStart" type="time" value="${data.start}"></div>
@@ -342,8 +384,9 @@ function renderProjects(){
   </div>`).join('');
 }
 
-// ---------- VFX Shots ----------
+// ---------- Shots ----------
 $('#btnNewShot').onclick=()=>openShotForm();
+$('#btnNewStoryboard').onclick=()=>openStoryboardForm();
 $('#shotStatusFilter').addEventListener('change', renderShots);
 function openShotForm(existing){
   let s = existing || {id:uid(), projectId:'', sequence:'', scene:'', shot:'', vendor:'', status:'Bid', due:'', notes:''};
@@ -374,8 +417,96 @@ function openShotForm(existing){
     if(!existing) store.shots.push(s);
     save(store); closeModal(); renderShots();
   }, existing ? ()=>{ store.shots = store.shots.filter(x=>x.id!==existing.id); save(store); renderShots(); } : null);
-}
-function renderShots(){
+  }
+
+  function openStoryboardForm(existing){
+    let board = existing || {id:uid(), title:'', shots:[]};
+    openModal(existing?'Edit Storyboard':'New Storyboard', (body)=>{
+      body.append(formRow(`<div><div class="small">Title</div><input id="sbTitle" value="${board.title}"></div>`));
+      body.append(formRow(`<div id="sbShots" style="display:flex;flex-direction:column;gap:10px"></div>`));
+      body.append(formRow(`<button class="btn" type="button" id="sbAddShot">+ Add Shot</button>`));
+    }, async ()=>{
+      board.title = $('#sbTitle').value.trim();
+      const container = $('#sbShots');
+      const items = Array.from(container.querySelectorAll('.sbItem'));
+      board.shots = [];
+      for(const item of items){
+        const id = item.dataset.id || uid();
+        const seq = item.querySelector('.sbSeq').value.trim();
+        const scene = item.querySelector('.sbScene').value.trim();
+        const shot = item.querySelector('.sbShot').value.trim();
+        const camera = item.querySelector('.sbCamera').value.trim();
+        const notes = item.querySelector('.sbNotes').value.trim();
+        const file = item.querySelector('.sbImage').files[0];
+        let image = item.dataset.image || '';
+        if(file){
+          image = await new Promise(res=>{ const r=new FileReader(); r.onload=e=>res(e.target.result); r.readAsDataURL(file); });
+        }
+        board.shots.push({id, sequence:seq, scene, shot, camera, notes, image});
+        let sh = store.shots.find(x=>x.id===id);
+        if(!sh){ sh={id, projectId:'', sequence:seq, scene, shot, vendor:'', status:'Bid', due:'', notes}; store.shots.push(sh); }
+        else { Object.assign(sh,{sequence:seq, scene, shot, notes}); }
+      }
+      if(!existing) store.storyboards.push(board);
+      save(store); closeModal(); renderStoryboards(); renderShots();
+    }, existing ? ()=>{ store.storyboards = store.storyboards.filter(x=>x.id!==existing.id); save(store); renderStoryboards(); } : null);
+
+    const container = $('#sbShots');
+    function addShotRow(data){
+      const id = data?.id || uid();
+      const div = document.createElement('div');
+      div.className='card sbItem';
+      div.dataset.id = id;
+      div.dataset.image = data?.image||'';
+      div.innerHTML = `
+        <div class="row">
+          <div class="space"><input class="sbSeq" placeholder="Seq" value="${data?.sequence||''}"></div>
+          <div class="space"><input class="sbScene" placeholder="Scene" value="${data?.scene||''}"></div>
+          <div class="space"><input class="sbShot" placeholder="Shot" value="${data?.shot||''}"></div>
+        </div>
+        <div class="row" style="margin-top:6px">
+          <div class="space"><input class="sbCamera" placeholder="Camera" value="${data?.camera||''}"></div>
+          <div class="space"><input class="sbImage" type="file" accept="image/*"></div>
+        </div>
+        ${data?.image?`<img src="${data.image}" style="width:100%;margin-top:6px">`:''}
+        <textarea class="sbNotes" placeholder="Notes" style="margin-top:6px">${data?.notes||''}</textarea>
+        <div class="row" style="margin-top:6px">
+          <button class="btn sbUp" type="button">↑</button>
+          <button class="btn sbDown" type="button">↓</button>
+          <div class="space"></div>
+          <button class="btn sbRemove" type="button">Remove</button>
+        </div>`;
+      container.appendChild(div);
+      div.querySelector('.sbUp').onclick=()=>{ if(div.previousElementSibling) container.insertBefore(div, div.previousElementSibling); };
+      div.querySelector('.sbDown').onclick=()=>{ if(div.nextElementSibling) container.insertBefore(div.nextElementSibling, div); };
+      div.querySelector('.sbRemove').onclick=()=>div.remove();
+    }
+    $('#sbAddShot').onclick=()=>addShotRow();
+    if(existing) existing.shots.forEach(addShotRow);
+  }
+
+  function renderStoryboards(){
+    const list = $('#storyboardsList'); list.innerHTML='';
+    if(!store.storyboards.length){ list.innerHTML='<div class="card small">No storyboards yet. Tap <b>+ Storyboard</b>.</div>'; return; }
+    list.innerHTML = store.storyboards.map(sb=>`
+      <div class="card">
+        <h3>${sb.title||'Storyboard'}</h3>
+        ${sb.shots.map(sh=>`
+          <div style="margin-top:8px">
+            ${sh.image?`<img src="${sh.image}" style="width:100%">`:''}
+            <div class="small">${sh.sequence||'SEQ'} / ${sh.scene||'SC'} / ${sh.shot||'SHOT'}${sh.camera?(' • Camera: '+sh.camera):''}</div>
+            <div class="small">${sh.notes||''}</div>
+          </div>
+        `).join('')}
+        <div class="row" style="margin-top:8px">
+          <button class="btn" onclick="openStoryboardForm(store.storyboards.find(x=>x.id==='${sb.id}'))">Edit</button>
+          <button class="btn" onclick="(function(){ store.storyboards=store.storyboards.filter(x=>x.id!=='${sb.id}'); save(store); renderStoryboards(); })()">Delete</button>
+        </div>
+      </div>
+    `).join('');
+  }
+
+  function renderShots(){
   const f = $('#shotStatusFilter').value;
   const list = $('#shotsList'); list.innerHTML='';
   let items = store.shots.slice().sort((a,b)=>(a.due||'').localeCompare(b.due||''));
@@ -401,23 +532,39 @@ function renderShots(){
 // ---------- Tasks ----------
 $('#btnNewTask').onclick=()=>openTaskForm();
 $('#taskFilter').addEventListener('change', renderTasks);
-function openTaskForm(prefill){
-  let t = {id:uid(), projectId:prefill?.projectId||'', title:'', due:'', status:'Open', notes:''};
-  openModal('New Task', (body)=>{
-    body.append(formRow(`<div><div class="small">Title</div><input id="tTitle" value="${t.title}"></div>`));
-    body.append(formRow(`<div class="row"><div class="space"><div class="small">Project</div><select id="tProj"><option value="">—</option>${store.projects.map(p=>`<option value="${p.id}" ${p.id===t.projectId?'selected':''}>${p.title}</option>`).join('')}</select></div>
-      <div class="space"><div class="small">Due</div><input id="tDue" type="date" value="${t.due}"></div></div>`));
-    body.append(formRow(`<div class="row"><div class="space"><div class="small">Status</div><select id="tStatus">${['Open','In Progress','Blocked','Done'].map(x=>`<option>${x}</option>`).join('')}</select></div></div>`));
-    body.append(formRow(`<div><div class="small">Notes</div><textarea id="tNotes">${t.notes}</textarea></div>`));
-  }, ()=>{
-    t.title = $('#tTitle').value.trim()||'Untitled Task';
-    t.projectId = $('#tProj').value;
-    t.due = $('#tDue').value;
-    t.status = $('#tStatus').value;
-    t.notes = $('#tNotes').value;
-    store.tasks.push(t); save(store); closeModal(); renderTasks();
-  });
-}
+$('#btnNewNote').onclick=()=>openNoteForm();
+$('#noteFilter').addEventListener('change', renderNotes);
+  function openTaskForm(prefill){
+    let t = {id:uid(), projectId:prefill?.projectId||'', title:'', due:'', status:'Open', notes:''};
+    openModal('New Task', (body)=>{
+      body.append(formRow(`<div><div class="small">Title</div><input id="tTitle" value="${t.title}"></div>`));
+      body.append(formRow(`<div class="row"><div class="space"><div class="small">Project</div><select id="tProj"><option value="">—</option>${store.projects.map(p=>`<option value="${p.id}" ${p.id===t.projectId?'selected':''}>${p.title}</option>`).join('')}</select></div>
+        <div class="space"><div class="small">Due</div><input id="tDue" type="date" value="${t.due}"></div></div>`));
+      body.append(formRow(`<div class="row"><div class="space"><div class="small">Status</div><select id="tStatus">${['Open','In Progress','Blocked','Done'].map(x=>`<option>${x}</option>`).join('')}</select></div></div>`));
+      body.append(formRow(`<div><div class="small">Notes</div><textarea id="tNotes">${t.notes}</textarea></div>`));
+    }, ()=>{
+      t.title = $('#tTitle').value.trim()||'Untitled Task';
+      t.projectId = $('#tProj').value;
+      t.due = $('#tDue').value;
+      t.status = $('#tStatus').value;
+      t.notes = $('#tNotes').value;
+      store.tasks.push(t); save(store); closeModal(); renderTasks();
+    });
+  }
+
+  function editTask(id){
+    const tt = store.tasks.find(x=>x.id===id); if(!tt) return;
+    openModal('Edit Task', (body)=>{
+      body.append(formRow(`<div><div class="small">Title</div><input id="tTitle" value="${tt.title}"></div>`));
+      body.append(formRow(`<div class="row"><div class="space"><div class="small">Project</div><select id="tProj"><option value="">—</option>${store.projects.map(p=>`<option value="${p.id}" ${p.id===tt.projectId?'selected':''}>${p.title}</option>`).join('')}</select></div>
+        <div class="space"><div class="small">Due</div><input id="tDue" type="date" value="${tt.due||''}"></div></div>`));
+      body.append(formRow(`<div class="row"><div class="space"><div class="small">Status</div><select id="tStatus">${['Open','In Progress','Blocked','Done'].map(x=>`<option ${tt.status===x?'selected':''}>${x}</option>`).join('')}</select></div></div>`));
+      body.append(formRow(`<div><div class="small">Notes</div><textarea id="tNotes">${tt.notes||''}</textarea></div>`));
+    }, ()=>{
+      tt.title=$('#tTitle').value; tt.projectId=$('#tProj').value; tt.due=$('#tDue').value; tt.status=$('#tStatus').value; tt.notes=$('#tNotes').value;
+      save(store); closeModal(); renderTasks();
+    }, ()=>{ store.tasks=store.tasks.filter(x=>x.id!==id); save(store); renderTasks(); });
+  }
 function renderTasks(){
   const f = $('#taskFilter').value;
   const list = $('#tasksList'); list.innerHTML='';
@@ -433,27 +580,111 @@ function renderTasks(){
         <div class="small">${t.notes||''}</div>
       </div>
       <div class="row" style="flex-direction:column;gap:8px">
-        <button class="btn" onclick="(function(id){ const tt=store.tasks.find(x=>x.id===id); if(!tt) return; openModal('Edit Task', (b)=>{
-          b.append(formRow('<div><div class=small>Title</div><input id=tTitle value="'+tt.title+'"></div>'));
-          b.append(formRow('<div class=row><div class=space><div class=small>Project</div><select id=tProj><option value="">—</option>'+store.projects.map(p=>'<option value="'+p.id+'" '+(p.id===tt.projectId?'selected':'')+'>'+p.title+'</option>').join('')+'</select></div><div class=space><div class=small>Due</div><input id=tDue type=date value="'+(tt.due||'')+'"></div></div>'));
-          b.append(formRow('<div class=row><div class=space><div class=small>Status</div><select id=tStatus>'+['Open','In Progress','Blocked','Done'].map(x=>'<option '+(tt.status===x?'selected':'')+'>'+x+'</option>').join('')+'</select></div></div>'));
-          b.append(formRow('<div><div class=small>Notes</div><textarea id=tNotes>'+ (tt.notes||'') +'</textarea></div>'));
-        }, ()=>{ tt.title=$('#tTitle').value; tt.projectId=$('#tProj').value; tt.due=$('#tDue').value; tt.status=$('#tStatus').value; tt.notes=$('#tNotes').value; save(store); closeModal(); renderTasks(); }, ()=>{ store.tasks=store.tasks.filter(x=>x.id!==id); save(store); renderTasks(); }); })('${t.id}')">Edit</button>
+        <button class="btn" onclick="editTask('${t.id}')">Edit</button>
         <button class="btn" onclick="(store.tasks=store.tasks.filter(x=>x.id!=='${t.id}'), save(store), renderTasks())">Delete</button>
       </div>
     </div>`;
   }).join('');
 }
 
-// ---------- FAB behavior ----------
-$('#fabAdd').onclick=()=>{
-  const active = document.querySelector('.tab.active')?.dataset.tab;
-  if(active==='calendar') openEventForm();
-  else if(active==='projects') openProjectForm();
-  else if(active==='shots') openShotForm();
-  else openTaskForm();
-};
+// ---------- Notes ----------
+function openNoteForm(existing){
+  let n = existing || {id:uid(), text:'', tags:[]};
+  openModal(existing?'Edit Note':'New Note', (body)=>{
+    body.append(formRow(`<div><div class="small">Text</div><textarea id="nText">${n.text}</textarea></div>`));
+    body.append(formRow(`<div id="nTags" style="display:flex;flex-direction:column;gap:6px"></div>`));
+    body.append(formRow(`<button class="btn" type="button" id="nAddTag">+ Tag</button>`));
+    body.append(formRow(`<button class="btn" type="button" id="nInsertLink">Insert Link</button>`));
+    }, ()=>{
+      n.text = $('#nText').value;
+      const tags=[];
+      $('#nTags').querySelectorAll('.tagRow').forEach(row=>{
+        const type=row.querySelector('.tagType').value;
+        const val=row.querySelector('.tagValue')?.value;
+        if(type && val) tags.push({type,id:val});
+      });
+      n.tags = tags;
+      if(!existing) store.notes.push(n);
+      save(store);
+      closeModal();
+      renderNotes();
+    }, existing ? ()=>{
+      store.notes = store.notes.filter(x=>x.id!==existing.id);
+      save(store);
+      renderNotes();
+    } : null);
 
+  function addTagRow(tag){
+    const div=document.createElement('div');
+    div.className='row tagRow';
+    div.innerHTML=`<div class="space"><select class="tagType">
+      <option value="">Type</option>
+      <option value="project">Project</option>
+      <option value="shot">Shot</option>
+      <option value="task">Task</option>
+      <option value="event">Event</option>
+      <option value="date">Date</option>
+      </select></div><div class="space tagWrap"></div><button class="btn" type="button" onclick="this.parentElement.remove()">Remove</button>`;
+    $('#nTags').appendChild(div);
+    const typeSel=div.querySelector('.tagType');
+    const wrap=div.querySelector('.tagWrap');
+    function populate(){
+      const t=typeSel.value; wrap.innerHTML='';
+      if(t==='project') wrap.innerHTML=`<select class="tagValue"><option value="">—</option>${store.projects.map(p=>`<option value="${p.id}">${p.title}</option>`).join('')}</select>`;
+      else if(t==='shot') wrap.innerHTML=`<select class="tagValue"><option value="">—</option>${store.shots.map(s=>`<option value="${s.id}">${s.sequence||'SEQ'}/${s.scene||'SC'}/${s.shot||'SHOT'}</option>`).join('')}</select>`;
+      else if(t==='task') wrap.innerHTML=`<select class="tagValue"><option value="">—</option>${store.tasks.map(t=>`<option value="${t.id}">${t.title}</option>`).join('')}</select>`;
+      else if(t==='event') wrap.innerHTML=`<select class="tagValue"><option value="">—</option>${store.events.map(e=>`<option value="${e.id}">${e.title} (${e.date})</option>`).join('')}</select>`;
+      else if(t==='date') wrap.innerHTML=`<input type="date" class="tagValue">`;
+      if(tag && tag.type===t){ wrap.querySelector('.tagValue').value=tag.id; }
+    }
+    typeSel.onchange=populate;
+    if(tag){ typeSel.value=tag.type; }
+    populate();
+  }
+  $('#nAddTag').onclick=()=>addTagRow();
+  if(n.tags) n.tags.forEach(addTagRow);
+
+  $('#nInsertLink').onclick=()=>{
+    const type = prompt('Link type (project/shot/task/event/date)');
+    if(!type) return;
+    let id='';
+    if(type==='date'){
+      id = prompt('Date (YYYY-MM-DD)')||'';
+    } else {
+      const arr = store[type+'s']||[];
+      if(!arr.length){ alert('No items'); return; }
+      const list = arr.map((it,i)=>`${i+1}. ${getLabel(type,it.id)}`).join('\n');
+      const pick = parseInt(prompt('Choose '+type+':\n'+list))-1;
+      if(isNaN(pick)||!arr[pick]) return;
+      id = arr[pick].id;
+    }
+      if(id){ const ta=$('#nText'); ta.value += ` [[${type}:${id}]]`; }
+    };
+  }
+
+function renderNotes(){
+  const filterSel = $('#noteFilter');
+  const val = filterSel.value;
+  let opts = '<option value="all">All</option>';
+  if(store.projects.length) opts += '<optgroup label="Projects">'+store.projects.map(p=>`<option value="project:${p.id}">${p.title}</option>`).join('')+'</optgroup>';
+  if(store.shots.length) opts += '<optgroup label="Shots">'+store.shots.map(s=>`<option value="shot:${s.id}">${s.sequence||'SEQ'}/${s.scene||'SC'}/${s.shot||'SHOT'}</option>`).join('')+'</optgroup>';
+  if(store.tasks.length) opts += '<optgroup label="Tasks">'+store.tasks.map(t=>`<option value="task:${t.id}">${t.title}</option>`).join('')+'</optgroup>';
+  if(store.events.length) opts += '<optgroup label="Events">'+store.events.map(e=>`<option value="event:${e.id}">${e.title} (${e.date})</option>`).join('')+'</optgroup>';
+  filterSel.innerHTML = opts;
+  filterSel.value = val==='all'||filterSel.querySelector(`option[value='${val}']`)?val:'all';
+  const f = filterSel.value;
+  const list = $('#notesList');
+  let items = store.notes.slice();
+  if(f!=='all'){ const [ft,fi] = f.split(':'); items = items.filter(n=>n.tags.some(t=>t.type===ft && t.id===fi)); }
+  if(items.length===0){ list.innerHTML='<div class="card small">No notes yet. Tap <b>+ Note</b>.</div>'; return; }
+  list.innerHTML = items.map(n=>`<div class="item card">
+      <div>${renderNoteText(n.text)}<div class="small">${n.tags.map(t=>getLabel(t.type,t.id)).join(', ')}</div></div>
+      <div class="row" style="flex-direction:column;gap:8px">
+        <button class="btn" onclick="openNoteForm(store.notes.find(x=>x.id==='${n.id}'))">Edit</button>
+        <button class="btn" onclick="(store.notes=store.notes.filter(x=>x.id!=='${n.id}'), save(store), renderNotes())">Delete</button>
+      </div>
+    </div>`).join('');
+}
 // ---------- Import / Export ----------
 $('#btnExport').onclick=()=>{
   const data = JSON.stringify(store, null, 2);
@@ -463,15 +694,25 @@ $('#btnExport').onclick=()=>{
   URL.revokeObjectURL(url);
 };
 $('#btnImport').onclick=()=>$('#fileImport').click();
-$('#fileImport').addEventListener('change', (ev)=>{
-  const file = ev.target.files[0]; if(!file) return;
-  const reader = new FileReader();
-  reader.onload = ()=>{ try{ store = JSON.parse(reader.result); save(store); render(); } catch{ alert('Invalid file'); } };
-  reader.readAsText(file); ev.target.value='';
-});
+  $('#fileImport').addEventListener('change', (ev)=>{
+    const file = ev.target.files[0];
+    if(!file) return;
+    const reader = new FileReader();
+    reader.onload = ()=>{
+      try{
+        store = JSON.parse(reader.result);
+        save(store);
+        render();
+      }catch(e){
+        alert('Invalid file');
+      }
+    };
+    reader.readAsText(file);
+    ev.target.value='';
+  });
 
 // ---------- Render all ----------
-function render(){ renderCalendar(); renderProjects(); renderShots(); renderTasks(); }
+function render(){ renderCalendar(); renderProjects(); renderStoryboards(); renderShots(); renderTasks(); renderNotes(); }
 function boot(){
   render();
   if('serviceWorker' in navigator){
@@ -482,3 +723,4 @@ boot();
 </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- handle calendar dates in local time to prevent incorrect day selection
- ensure agenda and new event forms use selected day consistently
- rename VFX Shots to Shots and add storyboard creator with image support
- respect device safe areas and apply full-page background for PWA view
- remove floating Add button and reduce calendar cell height by about 10% to prevent overlap
- add Notes tab with taggable links to projects, shots, tasks, events, or dates
- tidy storage initialization and note rendering, and replace legacy vfx chip styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce7842b648320afce6bfdb657bda1