### PR TITLE
feat: add PWA install banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,10 @@ textarea{min-height:90px;resize:vertical}
 .item+.item{margin-top:10px}
 .item h3{margin:0}
 .kicker{font-size:12px;color:var(--muted)}
+/* Install banner */
+#installBanner{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;text-align:center;z-index:1000;padding:20px}
+#installBanner .message{background:var(--panel);color:var(--text);border:1px solid var(--line);border-radius:12px;padding:20px;max-width:320px}
+#installBanner .message button{margin-top:10px}
 /* Modal */
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:none;align-items:flex-end;z-index:50}
     .sheet{width:100%;max-width:520px;margin:0 auto;background:linear-gradient(180deg,#151e29,#111822);border-top-left-radius:16px;border-top-right-radius:16px;border:1px solid var(--line);padding:14px;box-shadow:0 -10px 30px rgba(0,0,0,.35);max-height:90vh;overflow-y:auto;-webkit-overflow-scrolling:touch}
@@ -169,6 +173,13 @@ textarea{min-height:90px;resize:vertical}
   </section>
 
   <div class="footer">Offline‑ready • Add to Home Screen from Safari</div>
+</div>
+
+<div id="installBanner">
+  <div class="message">
+    <div>Pridať na plochu – v Safari klepni Zdieľať → Pridať na plochu.</div>
+    <button class="btn" id="installDismiss" type="button">Rozumiem</button>
+  </div>
 </div>
 
 <!-- Modal sheet -->
@@ -807,8 +818,32 @@ $('#fileImport').addEventListener('change', (ev)=>{
 
 // ---------- Render all ----------
 function render(){ renderCalendar(); renderProjects(); renderStoryboards(); renderShots(); renderTasks(); renderNotes(); }
+function setupInstallPrompt(){
+  const KEY='installPrompt';
+  const WAIT=3*24*60*60*1000;
+  const standalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+  const last = localStorage.getItem(KEY);
+  if(standalone){ localStorage.setItem(KEY,'done'); return; }
+  if(last==='done') return;
+  if(last && Date.now()-Number(last) < WAIT) return;
+  if(/iphone|ipad|ipod/i.test(navigator.userAgent)){
+    const b=document.getElementById('installBanner');
+    b.style.display='flex';
+    document.getElementById('installDismiss').onclick=()=>{
+      b.style.display='none';
+      localStorage.setItem(KEY, Date.now());
+    };
+  } else {
+    window.addEventListener('beforeinstallprompt', e=>{
+      e.preventDefault();
+      e.prompt();
+      e.userChoice.finally(()=>localStorage.setItem(KEY, Date.now()));
+    }, {once:true});
+  }
+}
 function boot(){
   render();
+  setupInstallPrompt();
   if('serviceWorker' in navigator){
     window.addEventListener('load', ()=> navigator.serviceWorker.register('./sw.js').catch(console.error));
   }


### PR DESCRIPTION
## Summary
- add iOS overlay banner prompting users to add PWA to home screen
- trigger Android install prompt via `beforeinstallprompt`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a34a36aabc8320a8e08a23cc4d6182