### PR TITLE
feat: add install instructions overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,12 +59,20 @@ textarea{min-height:90px;resize:vertical}
 .item+.item{margin-top:10px}
 .item h3{margin:0}
 .kicker{font-size:12px;color:var(--muted)}
+/* Install guide */
+#installOverlay{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;text-align:center;z-index:1000;padding:20px}
+#installOverlay .box{background:var(--panel);color:var(--text);border:1px solid var(--line);border-radius:12px;padding:20px;max-width:320px;width:100%}
+#installOverlay .platforms{display:flex;justify-content:center;gap:14px;margin:10px 0}
+#installOverlay .platforms button{background:none;border:none;font-size:32px;cursor:pointer;color:var(--text)}
+#installOverlay .title{font-weight:900;margin-bottom:10px}
+#installInstructions{font-size:14px;line-height:1.4}
+#installInstructions div{margin-top:8px}
 /* Modal */
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.55);display:none;align-items:flex-end;z-index:50}
     .sheet{width:100%;max-width:520px;margin:0 auto;background:linear-gradient(180deg,#151e29,#111822);border-top-left-radius:16px;border-top-right-radius:16px;border:1px solid var(--line);padding:14px;box-shadow:0 -10px 30px rgba(0,0,0,.35);max-height:90vh;overflow-y:auto;-webkit-overflow-scrolling:touch}
 .sheet .title{font-weight:900;margin:0 0 8px 0}
 .sheet .grid{display:grid;gap:10px}
-.footer{margin-top:14px;text-align:center;color:var(--muted);font-size:12px}
+.footer{margin-top:14px;text-align:center;color:var(--muted);font-size:12px;cursor:pointer}
 @media (orientation:landscape){body::before{content:'Rotate to portrait for best experience';position:fixed;inset:0;display:grid;place-items:center;background:rgba(0,0,0,.6);z-index:9999;color:#fff}}
 </style>
 </head>
@@ -168,7 +176,20 @@ textarea{min-height:90px;resize:vertical}
     <div id="notesList" style="margin-top:10px"></div>
   </section>
 
-  <div class="footer">Offline‑ready • Add to Home Screen from Safari</div>
+  <div class="footer" id="showInstall">Add to Home Screen</div>
+</div>
+
+<div id="installOverlay">
+  <div class="box">
+    <div class="title">Install</div>
+    <div class="platforms">
+      <button id="install-ios" aria-label="iOS"></button>
+      <button id="install-android" aria-label="Android">🤖</button>
+      <button id="install-windows" aria-label="Windows">🪟</button>
+    </div>
+    <div id="installInstructions">Select a platform to view instructions.</div>
+    <button class="btn" id="installClose" type="button" style="margin-top:10px">Close</button>
+  </div>
 </div>
 
 <!-- Modal sheet -->
@@ -807,8 +828,42 @@ $('#fileImport').addEventListener('change', (ev)=>{
 
 // ---------- Render all ----------
 function render(){ renderCalendar(); renderProjects(); renderStoryboards(); renderShots(); renderTasks(); renderNotes(); }
+function setupInstallGuide(){
+  const INSTALL_KEY='installGuideDismissed';
+  const overlay=document.getElementById('installOverlay');
+  const instructions=document.getElementById('installInstructions');
+  const standalone = window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone;
+  const steps={
+    ios:[
+      '<strong>Safari:</strong> Open in Safari → Tap Share → Add to Home Screen.',
+      '<strong>Chrome:</strong> Open in Chrome → Tap Share (⋮) → Add to Home Screen.',
+      '<strong>Firefox:</strong> Open in Firefox → Tap Share → Add to Home Screen.'
+    ],
+    android:[
+      '<strong>Chrome:</strong> Open in Chrome → Tap Menu (⋮) → Add to Home Screen (or Install App).',
+      '<strong>Firefox:</strong> Open in Firefox → Tap Menu (⋮) → Add to Home Screen.',
+      '<strong>Edge:</strong> Open in Edge → Tap Menu (⋮) → Add to Phone.'
+    ],
+    windows:[
+      '<strong>Edge:</strong> Open in Edge → Menu (⋮) → Apps → Install this site as an app.',
+      '<strong>Chrome:</strong> Open in Chrome → Menu (⋮) → Install this site as an app.',
+      '<strong>Firefox:</strong> Firefox does not support direct installation. Use Edge or Chrome instead.'
+    ]
+  };
+  function show(){ overlay.style.display='flex'; }
+  function hide(){ overlay.style.display='none'; localStorage.setItem(INSTALL_KEY,'1'); }
+  document.getElementById('installClose').onclick=hide;
+  document.getElementById('showInstall').onclick=show;
+  ['ios','android','windows'].forEach(p=>{
+    document.getElementById('install-'+p).onclick=()=>{
+      instructions.innerHTML=steps[p].map(t=>`<div>${t}</div>`).join('');
+    };
+  });
+  if(!standalone && !localStorage.getItem(INSTALL_KEY)) show();
+}
 function boot(){
   render();
+  setupInstallGuide();
   if('serviceWorker' in navigator){
     window.addEventListener('load', ()=> navigator.serviceWorker.register('./sw.js').catch(console.error));
   }


### PR DESCRIPTION
## Summary
- show platform-specific instructions for adding the PWA to the home screen
- allow reopening the install guide from footer link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34a36aabc8320a8e08a23cc4d6182